### PR TITLE
Fix line weight issues with dynamic font

### DIFF
--- a/src/c/text_render.c
+++ b/src/c/text_render.c
@@ -10,7 +10,6 @@
 // @bug No known bugs
 
 #include "text_render.h"
-
 #include <pebble.h>
 
 // Constants
@@ -70,6 +69,13 @@ static Character *LECO_CHARS[] = {&LECO_0, &LECO_1, &LECO_2, &LECO_3, &LECO_4, &
 // Private Functions
 //
 
+static int16_t prv_scale_character_point(int16_t value, int16_t char_size, int16_t font_size) {
+  int16_t centered_value = value - (char_size / 2);
+  int16_t scaled_value = centered_value * font_size / CHARACTER_DEFINITION_HEIGHT;
+  int16_t offset_value = scaled_value + (char_size * font_size / CHARACTER_DEFINITION_HEIGHT / 2);
+  return offset_value;
+}
+
 // Draw a LECO character
 static void prv_draw_character(GContext *ctx, GPath *path, Character *leco_char, uint16_t font_size,
                                GPoint position) {
@@ -77,8 +83,10 @@ static void prv_draw_character(GContext *ctx, GPath *path, Character *leco_char,
   path->num_points = leco_char->num_points;
   memcpy(path->points, leco_char->points, sizeof(leco_char->points));
   for (uint8_t kk = 0; kk < leco_char->num_points; kk++) {
-    path->points[kk].x = path->points[kk].x * font_size / CHARACTER_DEFINITION_HEIGHT;
-    path->points[kk].y = path->points[kk].y * font_size / CHARACTER_DEFINITION_HEIGHT;
+    path->points[kk].x =
+        prv_scale_character_point(path->points[kk].x, leco_char->char_width, font_size);
+    path->points[kk].y =
+        prv_scale_character_point(path->points[kk].y, CHARACTER_DEFINITION_HEIGHT, font_size);
   }
   path->offset = position;
   gpath_draw_filled(ctx, path);


### PR DESCRIPTION
At certain resolutions the line weights for different font elements would be inconsistent due to how the scaling math was being performed. This applies the scaling from the inside out so that the line weights are more consistent over the characters. The issue is most noticeable on the zeros.

Before:
<img width="1375" height="314" alt="Screenshot from 2026-02-22 15-58-01" src="https://github.com/user-attachments/assets/8b8860b0-1adc-4443-8a39-2686925f065f" />

After:
<img width="1375" height="314" alt="Screenshot from 2026-02-22 16-06-08" src="https://github.com/user-attachments/assets/faea9e38-c8c2-45b5-8787-dae8886a0616" />
