### PR TITLE
Add Timeline Pin support for timers over 30 minutes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,44 @@
       "name": "pebble-timer-plus",
       "version": "4.2.0",
       "dependencies": {
-        "pebble-scalable": "^2.2.0"
+        "pebble-packet": "^1.6.0",
+        "pebble-scalable": "^2.2.0",
+        "pebble-timeline-js": "^2.2.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.8.1"
       }
+    },
+    "node_modules/pebble-packet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pebble-packet/-/pebble-packet-1.6.0.tgz",
+      "integrity": "sha512-R59pwtaNKC64yA22Wz3AHD95wWSb/ADWYmdc1xGGBUIBoAP+4HVYIOUPOb5DRwzNiawCB3ImeMt8ZLrAlM+pHw=="
     },
     "node_modules/pebble-scalable": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pebble-scalable/-/pebble-scalable-2.2.0.tgz",
       "integrity": "sha512-JbeioWDaCrrvk0bj4VRWWvAuaPUFnblE83YS7Iu9Ew5mLcxsr7szs03aeHI2q+qL1Opr+YL+z3Mp2rVhfBpBww=="
+    },
+    "node_modules/pebble-timeline-js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pebble-timeline-js/-/pebble-timeline-js-2.2.0.tgz",
+      "integrity": "sha512-3MY20j7ZvAbZ/DnoayAuQx8OkClHXjJYyVh46Uk4NCrzDR/thHDuP/mnXlNw9FYk3CEuirdEB9wV6gy5StyOSQ=="
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,21 @@
   ],
   "private": true,
   "dependencies": {
-    "pebble-scalable": "^2.2.0"
+    "pebble-packet": "^1.6.0",
+    "pebble-scalable": "^2.2.0",
+    "pebble-timeline-js": "^2.2.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.1"
+  },
+  "scripts": {
+    "prettier": "npx prettier src/pkjs --write"
   },
   "pebble": {
     "displayName": "Timer+",
     "uuid": "17bf83aa-88a9-459a-a6e5-60aa60e1dc07",
     "sdkVersion": "3",
-    "enableMultiJS": false,
+    "enableMultiJS": true,
     "targetPlatforms": [
       "aplite",
       "basalt",
@@ -42,6 +50,10 @@
           "characterRegex": "[0-9: ]"
         }
       ]
-    }
+    },
+    "messageKeys": [
+      "type",
+      "update_timeline_pin_time"
+    ]
   }
 }

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -237,6 +237,11 @@ static void prv_tick_timer_service_callback(struct tm *tick_time, TimeUnits unit
 static void prv_initialize(void) {
   // cancel any existing wakeup events
   wakeup_cancel_all();
+
+  // initialize app messages
+  packet_init();
+  app_message_open(0, 64);
+
   // load timer
   timer_persist_read();
   // set initial states
@@ -282,10 +287,21 @@ static void prv_initialize(void) {
 static void prv_terminate(void) {
   // unsubscribe from timer service
   tick_timer_service_unsubscribe();
-  // schedule wakeup
   if (!timer_is_chrono() && !timer_is_paused()) {
+    // schedule wakeup
     time_t wakeup_time = (epoch() + timer_get_value_ms()) / MSEC_IN_SEC;
     wakeup_schedule(wakeup_time, 0, true);
+
+    if ((timer_get_value_ms() / MSEC_IN_MIN) > 30) {
+      // update timeline pin
+      update_timeline_pin(wakeup_time);
+    } else {
+      // remove timeline pin
+      update_timeline_pin(0);
+    }
+  } else {
+    // remove timeline pin
+    update_timeline_pin(0);
   }
   // destroy
   timer_persist_store();

--- a/src/c/utility.c
+++ b/src/c/utility.c
@@ -91,3 +91,19 @@ void *malloc_check(uint16_t size, const char *file, int line) {
 
 // Get current epoch in milliseconds
 uint64_t epoch(void) { return (uint64_t)time(NULL) * 1000 + (uint64_t)time_ms(NULL, NULL); }
+
+// Update the timeline pin with a wakeup time
+void update_timeline_pin(time_t wakeup_time) {
+  if (packet_begin()) {
+    if (packet_put_string(MESSAGE_KEY_type, "update_timeline_pin") &&
+        packet_put_integer(MESSAGE_KEY_update_timeline_pin_time, wakeup_time)) {
+      if (!packet_send(NULL)) {
+        APP_LOG(APP_LOG_LEVEL_ERROR, "Failed to send timeline pin update message");
+      }
+    } else {
+      APP_LOG(APP_LOG_LEVEL_ERROR, "Failed to write timeline pin update message");
+    }
+  } else {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Failed to begin timeline pin update message");
+  }
+}

--- a/src/c/utility.h
+++ b/src/c/utility.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include <pebble.h>
+#include <pebble-packet/pebble-packet.h>
 
 //! Time span conversions
 #define MSEC_IN_HR 3600000
@@ -58,3 +59,7 @@ void *malloc_check(uint16_t size, const char *file, int line);
 //! Get current epoch in milliseconds
 //! @return The current epoch time in milliseconds
 uint64_t epoch(void);
+
+//! Update the timeline pin with a wakeup time
+//! @param wakeup_time The time to set the timeline pin to in seconds since epoch, or 0 to remove the timeline pin
+void update_timeline_pin(time_t wakeup_time);

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -1,0 +1,42 @@
+const PebbleTimelineJs = require("pebble-timeline-js");
+
+const NEXT_TIMER_TIMELINE_PIN_ID = "pebble-timer-plus-next-timer-timeline-pin";
+
+Pebble.addEventListener("ready", function (_) {
+  console.log("PebbleKit JS ready!");
+});
+
+Pebble.addEventListener("appmessage", function (event) {
+  console.log("Received message: " + JSON.stringify(event.payload));
+
+  if (!event.payload || !("type" in event.payload)) return;
+  const payload = event.payload;
+
+  console.log("Received message of type: " + payload.type);
+  switch (payload.type) {
+    case "update_timeline_pin":
+      if (Pebble.deleteTimelinePin) {
+        Pebble.deleteTimelinePin(NEXT_TIMER_TIMELINE_PIN_ID);
+      } else {
+        PebbleTimelineJs.deleteUserPin({ id: NEXT_TIMER_TIMELINE_PIN_ID });
+      }
+      if (payload.update_timeline_pin_time > 0) {
+        const nextTimerTime = new Date(payload.update_timeline_pin_time * 1000);
+        const timelinePin = {
+          id: NEXT_TIMER_TIMELINE_PIN_ID,
+          time: nextTimerTime,
+          layout: {
+            type: "genericPin",
+            title: "Timer Done",
+            tinyIcon: "system://images/ALARM_CLOCK",
+          },
+        };
+        if (Pebble.insertTimelinePin) {
+          Pebble.insertTimelinePin(timelinePin);
+        } else {
+          PebbleTimelineJs.insertUserPin(timelinePin);
+        }
+      }
+      break;
+  }
+});


### PR DESCRIPTION
Not sure if you have interest in this in main.

This adds support for pushing timeline pins to the user when they set a timer over 30 minutes (technically over 30 minutes and 59 seconds).

This is a feature that the official Pebble Timer has, though it pushes pins for timers over 15 minutes.

This will let the Quick Peek (is that what it is called) view appear on the user's watch face to let them know when their timer is about to finish in the background, in addition to the Timeline pin

I added a few packages to handle some of the specific details of stuff like app messaging and non-Core Timeline support, since as of now this is the only feature that needs any of it. Getting rid of those packages is fairly trivial but would just increase project-specific code in exchange for less library code (they're very small libraries)

![JPEG image-413D-BC0E-F3-0](https://github.com/user-attachments/assets/321282d0-1f38-4847-b040-a3ecb2ddce14) ![JPEG image-4464-BF9E-34-0](https://github.com/user-attachments/assets/f36c9d9b-d0f9-4b57-9e1c-4cae91837601)
