### PR TITLE
Fix bug causing errant vibration on launch

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -60,7 +60,7 @@ static void prv_layer_update_proc_handler(Layer *layer, GContext *ctx) {
 // Back click handler
 static void prv_back_click_handler(ClickRecognizerRef recognizer, void *ctx) {
   // cancel vibrations
-  vibes_cancel();
+  main_timer_rewind();
   // get time parts
   uint16_t hr, min, sec;
   timer_get_time_parts(&hr, &min, &sec);

--- a/src/c/timer.c
+++ b/src/c/timer.c
@@ -79,7 +79,7 @@ bool timer_is_paused(void) { return timer_data.start_ms <= 0; }
 
 // Check if the timer is elapsed and vibrate if this is the first call after elapsing
 void timer_check_elapsed(void) {
-  if (timer_is_chrono() && !timer_is_paused() && timer_data.can_vibrate) {
+  if (timer_is_vibrating()) {
     // stop vibration after certain duration
     if (timer_get_value_ms() > VIBRATION_LENGTH_MS) {
       timer_data.can_vibrate = false;


### PR DESCRIPTION
Fix a bug where previously pressing the back button while the timer was vibrating would exit the app without dismissing the timer. Opening the app again would cause the timer to vibrate again if it was still within its 20s window.

New behavior is the back button is overridden such that pressing it while the timer is going off will simply cancel the timer and return to the timer edit screen (without closing the app). If the app is closed by another application it WILL still go off again when the user re-opens the app (full vibrations if within 20s and a single vibration pulse if after that point).